### PR TITLE
end of day save: notes in comment

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,5 +1,6 @@
 .App {
   text-align: center;
+  
 }
 
 .App-logo {
@@ -14,7 +15,7 @@
 }
 
 .App-header {
-  background-color: #282c34;
+  background-color: #0052f5;
   min-height: 100vh;
   display: flex;
   flex-direction: column;

--- a/src/Components/LandingImgGallery/LandingImgGallery.jsx
+++ b/src/Components/LandingImgGallery/LandingImgGallery.jsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import ImageList from '@mui/material/ImageList';
+import ImageListItem from '@mui/material/ImageListItem';
+
+export default function LandingImgGallery() {
+    return (
+        <ImageList sx={{ height: 250, borderRadius: "5px", width: "75%" }} variant="woven" cols={4} gap={8}>
+            {itemData.map((item) => (
+                <ImageListItem key={item.img}>
+                    <img
+                        style={{ borderRadius: "5px" }}
+                        src={`${item.img}?w=161&fit=crop&auto=format`}
+                        srcSet={`${item.img}?w=161&fit=crop&auto=format&dpr=2 2x`}
+                        alt={item.title}
+                        loading="lazy"
+                    />
+                </ImageListItem>
+            ))}
+        </ImageList>
+    );
+}
+
+const itemData = [
+    {
+        img: 'https://images.unsplash.com/photo-1549388604-817d15aa0110',
+        title: 'Bed',
+    },
+    {
+        img: 'https://images.unsplash.com/photo-1563298723-dcfebaa392e3',
+        title: 'Kitchen',
+    },
+    {
+        img: 'https://images.unsplash.com/photo-1523413651479-597eb2da0ad6',
+        title: 'Sink',
+    },
+    {
+        img: 'https://images.unsplash.com/photo-1525097487452-6278ff080c31',
+        title: 'Books',
+    },
+    {
+        img: 'https://images.unsplash.com/photo-1574180045827-681f8a1a9622',
+        title: 'Chairs',
+    },
+    {
+        img: 'https://images.unsplash.com/photo-1597262975002-c5c3b14bbd62',
+        title: 'Candle',
+    },
+    {
+        img: 'https://images.unsplash.com/photo-1530731141654-5993c3016c77',
+        title: 'Laptop',
+    },
+    {
+        img: 'https://images.unsplash.com/photo-1481277542470-605612bd2d61',
+        title: 'Doors',
+    },
+    {
+        img: 'https://images.unsplash.com/photo-1517487881594-2787fef5ebf7',
+        title: 'Coffee',
+    },
+    {
+        img: 'https://images.unsplash.com/photo-1516455207990-7a41ce80f7ee',
+        title: 'Storage',
+    },
+    {
+        img: 'https://images.unsplash.com/photo-1519710164239-da123dc03ef4',
+        title: 'Coffee table',
+    },
+    {
+        img: 'https://images.unsplash.com/photo-1588436706487-9d55d73a39e3',
+        title: 'Blinds',
+    },
+];

--- a/src/Components/Slide/Slide.jsx
+++ b/src/Components/Slide/Slide.jsx
@@ -1,0 +1,91 @@
+import { Box, Container, ImageList, ImageListItem, Typography } from "@mui/material"
+import React from "react"
+import DecreaseBtn from "../ControlBtns/DecreaseBtn/DecreaseBtn"
+import IncreaseBtn from "../ControlBtns/IncreaseBtn/IncreaseBtn"
+import ResetBtn from "../ControlBtns/ResetBtn/ResetBtn"
+
+
+
+
+function Slide(props) {
+
+    return (
+        <>
+            <Container sx={{ display: "flex", flexDirection: "column", height: "75vh", borderRadius: "5px" }}>
+
+                <Box sx={{ display: "flex", height: "95%" }}>
+                    <Box sx={{ width: "45%", backgroundColor: "green", display: "flex", flexDirection: "column", justifyContent: "space-evenly" }}>
+                        <Typography variant="h1">{props.id}</Typography>
+                        <Typography variant="p">Lorem ipsum dolor sit amet consectetur, adipisicing elit. Id deserunt corporis, vitae maxime voluptatibus modi doloremque quibusdam ratione possimus, omnis quis voluptatem fuga minima, alias cupiditate eius! Vel, excepturi deserunt!</Typography>
+                        <Typography variant="p">Lorem ipsum dolor sit amet consectetur, adipisicing elit. Id deserunt corporis, vitae maxime voluptatibus modi doloremque quibusdam ratione possimus, omnis quis voluptatem fuga minima, alias cupiditate eius! Vel, excepturi deserunt!</Typography>
+                    </Box>
+                    <Box sx={{ width: "55%", backgroundColor: "blue", display: "flex", alignItems: "center", justifyContent: "center" }}>
+                        <ImageList variant="masonry" sx={{ height: 350, borderRadius: "5px", width: "75%" }} cols={3} gap={8}>
+                            {itemData.map((item) => (
+                                <ImageListItem key={item.img}>
+                                    <img
+                                        style={{ borderRadius: "5px" }}
+                                        src={`${item.img}?w=150&fit=crop&auto=format`}
+                                        srcSet={`${item.img}?w=150&fit=crop&auto=format&dpr=2 2x`}
+                                        alt={item.title}
+                                        loading="lazy"
+                                    />
+                                </ImageListItem>
+                            ))}
+                        </ImageList>
+                    </Box>
+                </Box>
+                <Box sx={{ width: "100%", display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+                    <DecreaseBtn />
+                    <ResetBtn />
+                    <IncreaseBtn />
+
+
+                </Box>
+            </Container>
+        </>
+    )
+}
+
+
+
+
+const itemData = [
+    {
+        img: 'https://images.unsplash.com/photo-1549388604-817d15aa0110',
+        title: 'Bed',
+    },
+    {
+        img: 'https://images.unsplash.com/photo-1525097487452-6278ff080c31',
+        title: 'Books',
+    },
+    {
+        img: 'https://images.unsplash.com/photo-1523413651479-597eb2da0ad6',
+        title: 'Sink',
+    },
+    {
+        img: 'https://images.unsplash.com/photo-1563298723-dcfebaa392e3',
+        title: 'Kitchen',
+    },
+    {
+        img: 'https://images.unsplash.com/photo-1588436706487-9d55d73a39e3',
+        title: 'Blinds',
+    },
+    {
+        img: 'https://images.unsplash.com/photo-1574180045827-681f8a1a9622',
+        title: 'Chairs',
+    },
+    {
+        img: 'https://images.unsplash.com/photo-1530731141654-5993c3016c77',
+        title: 'Laptop',
+    },
+
+
+
+
+
+];
+
+
+
+export default Slide

--- a/src/Components/TaskView/TaskView.jsx
+++ b/src/Components/TaskView/TaskView.jsx
@@ -1,16 +1,15 @@
 import {
-    Card,
-    CardActions,
-    CardContent,
-    Paper,
-    Typography, Container
+    ImageList, ImageListItem, Container,
+    Typography,
 } from "@mui/material";
-import { styled } from "@mui/system";
+import { Box, styled } from "@mui/system";
 import { React, useContext } from "react";
 import Context from "../../Context/Context";
 import DecreaseBtn from "../ControlBtns/DecreaseBtn/DecreaseBtn";
 import IncreaseButton from "../ControlBtns/IncreaseBtn/IncreaseBtn";
 import ResetBtn from "../ControlBtns/ResetBtn/ResetBtn";
+
+import Slide from "../Slide/Slide"
 
 function ResultBox() {
     const context = useContext(Context);
@@ -37,19 +36,24 @@ function ResultBox() {
             return <Error>Please Reset Counter</Error>;
         } else {
             //console.log("Between");
-            return <Value>{data[`${count}`].name}</Value>;
+            return <Slide name={data[`${count}`].name} id={data[`${count}`].id} email={data[`${count}`].email} />;
         }
+
     }
-
-
 
     console.log(count);
 
     return (
         <>
+            <Control />
+        </>
+    );
+}
 
-            <Card
-                sx={{ backgroundColor: "surfaces.primary", width: "175px" }}
+
+export default ResultBox;
+{/* <Card
+                sx={{ backgroundColor: "surfaces.primary", width: "80vw", height: 550, borderRadius: "5px", display: "flex", flexDirection: "column", justifyContent: "space-between" }}
                 component={Paper}
                 elevation={8}
             >
@@ -63,8 +67,5 @@ function ResultBox() {
                 </CardActions>
             </Card>
 
-        </>
-    );
-}
 
-export default ResultBox;
+ */}

--- a/src/Pages/Home.jsx
+++ b/src/Pages/Home.jsx
@@ -5,17 +5,25 @@
 */
 
 import React from 'react'
-import { Container } from "@mui/material"
+import { Container, Box } from "@mui/material"
 
 import OnPageNav from '../Components/OnPageNav/OnPageNav'
+import LandingImgGallery from '../Components/LandingImgGallery/LandingImgGallery'
 
 function Home() {
 
 
     return (
-        <Container>
-            <h1>Home</h1>
+
+
+
+        <Container sx={{ display: "flex", flexDirection: "column", justifyContent: "space-evenly", alignItems: "center", height: "100vh", }}>
+
+            <LandingImgGallery />
+
+
             <OnPageNav />
+
         </Container>
     )
 }

--- a/src/Pages/View.jsx
+++ b/src/Pages/View.jsx
@@ -21,10 +21,12 @@ function View() {
 
 
     return (
-        <Container sx={{ display: "flex", justifyContent: "center", alignItems: "center", height: "100vh", backgroundColor: "red" }}>
-            <Box sx={{ backgroundColor: "blue", padding: "5px" }}>
-                <TaskView />
-            </Box>
+        <Container maxWidth="xl" sx={{
+            height: "100vh",
+            display: "flex", justifyContent: "center", alignItems: "center",
+        }}>
+
+            <TaskView />
 
         </Container>
     )


### PR DESCRIPTION
End of day Save. Added English component + logic for slideshow on View tab. Not entirely happy with the result but will improve in time. v1 of the repo will be pure frontend using JSON placeholder. Offering the same navigation that would be offered in the MVP stage. It interesting that I've managed to avoid mapping data from Axios call to comps. rn using view/ count logic works quite well. 


ToDO:
-move Navi comp out of slide comp: doesn't work with current logic. if the counter is = -1 or more than the length of the fetch array it only returns error comp with no chance to reset the counter but reload the page. 

-Look more into the image list. makes sense for the project because you can display multiple images and even add an on click to each image that will open up a dialogue with a fullscreen view of the tool/step

